### PR TITLE
Fixed 2 broken links on wsgi page

### DIFF
--- a/manage/deploying/wsgi.rst
+++ b/manage/deploying/wsgi.rst
@@ -17,8 +17,8 @@ Plone and WSGI
 
 Collection of Links about this topic, since this is a very special topic we also link to documentation about WSGI and Plone 4 for reference.
 
-* `Zope 4 and WSGI <https://zope.readthedocs.io/en/latest/wsgi.html>`_
+* `Zope 4 and WSGI <https://zope.readthedocs.io/en/latest/operation.html#using-alternative-wsgi-server-software>`_
 
-* `Plone 4 with WSGI <http://comments.gmane.org/gmane.comp.web.zope.plone.devel/23886>`_
+* `Plone 4 with WSGI <https://comments.gmane.org/gmane.comp.web.zope.plone.devel/23886>`_
 
-* `Plone 5 with WSGI <http://blog.toms-projekte.de/run-plone-with-wsgi.html>`_
+* `Plone 5 with WSGI <https://blog.toms-projekte.de/run-plone-with-wsgi.html>`_


### PR DESCRIPTION
Fixed broken "Zope 4 and WSGI" and "Plone 5 with WSGI" links.

Thank you for your contribution to the Plone Documentation.

Before submitting this PR, please make sure:

- [x] You are following our [Documentation Styleguide](https://docs.plone.org/about/contributing/documentation_styleguide.html)
- [x] You are following our [General Writing Guidelines](https://docs.plone.org/about/contributing/rst-styleguide.html)

Fixes: #

Improves:

Changes proposed in this pull request:

-

-

-


